### PR TITLE
Hide social media icons on small devices

### DIFF
--- a/src/css/less/sections.less
+++ b/src/css/less/sections.less
@@ -734,3 +734,12 @@ ul.start_abheben {
   }
 
 }
+
+//nav:social media
+section.social-icons {
+  display: none;
+
+  @media (min-width: 992px) {
+    display: block;
+  }
+}


### PR DESCRIPTION
the social media section will be hidden below 992px window width
