### PR TITLE
rocket fix

### DIFF
--- a/src/css/less/rocket.less
+++ b/src/css/less/rocket.less
@@ -49,14 +49,15 @@
 */
 // keyframes
 @keyframes flames {
-  0%   {transform: scale(1, 1)}
-  50%  {transform: scale(1, 0.75)}
-  100% {transform: scale(1, 1)}
+  0%   { transform: scale(1, 1)}
+  50%  { transform: scale(1, 0.75)}
+  100% { transform: scale(1, 1)}
 }
 
 #rocket-burst path {
   animation: flames .8s ease-in-out infinite;
   transform-origin: center top;
+  -moz-transform-origin: 0 70%;
 }
 
 /* rotate the rocket when scrolling down

--- a/src/css/less/rocket.less
+++ b/src/css/less/rocket.less
@@ -49,9 +49,9 @@
 */
 // keyframes
 @keyframes flames {
-  0%   { transform: scale(1, 1)}
-  50%  { transform: scale(1, 0.75)}
-  100% { transform: scale(1, 1)}
+  0%   {transform: scale(1, 1)}
+  50%  {transform: scale(1, 0.75)}
+  100% {transform: scale(1, 1)}
 }
 
 #rocket-burst path {


### PR DESCRIPTION
SVG, so gerne wir sie haben sind einfach noch nicht so gut standardisiert. Firefox kommt mit dem transform-origin noch nicht so gut klar, bzw. interpretiert es anders. Ich habe mit einem prefix eine alternative für den Mozilla Browser gemacht, der einigermaßen passt.


fixes #4 