### PR TITLE
width des Lade-Icons berichtigt

### DIFF
--- a/src/css/less/wrapper.less
+++ b/src/css/less/wrapper.less
@@ -10,6 +10,7 @@
 }
 
 .img-load {
+  width: 100px;
   display: block;
   margin: 0 auto;
 }


### PR DESCRIPTION
Da keine width für .img-load definiert war, wurden die beiden SVGs über
die 100% Seitenbreite gezogen und die Werte in den classes
.img-loadingRocket und .img-rotate30 gar nicht erst geladen. Habe daher
für .img-load die gleiche Breite wie die der Rocket definiert.

@topada wenn das in Ordnung ist, bitte mergen.